### PR TITLE
npm installのエラー解消

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "gulp-open": "^0.3.1",
     "gulp-pleeease": "^1.1.0",
     "gulp-plumber": "^0.6.6",
-    "gulp-react": "^2.1.0",
+    "gulp-react": "^2.0.0",
     "gulp-sass": "^1.3.3",
     "gulp-serve": "^0.3.0",
     "gulp-sourcemaps": "^1.3.0",


### PR DESCRIPTION
Mac, Windows両者ともnpm installでエラーが出たので解消

初Pull requestなので、練習でもあります。
npm installした所、gulp-reactがvalidなバージョンでないと出ました。
2.0.0にすると解消したので、pull requestを送ります。